### PR TITLE
Resolve relative URLs to aboslute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,11 @@ const enhancePage = function(dom) {
 };
 
 function createDom({ url, content }) {
-	const dom = new JSDOM(content);
-	dom.reconfigure({ url });
+	const dom = new JSDOM(content, { url });
+
+	// Force relative URL resolution
+	dom.window.document.body.setAttribute(null, null);
+
 	return dom;
 }
 


### PR DESCRIPTION
## Description
Relative paths in a tags link to (non existent) local files instead of the resolve to an absolute path. This PR should resolve this problem.

## Proposed solution
A simple `reconfigure` call or creating the `JSDOM` object with a given URL, is not enough to force the relative URL resolution. I added a line that triggers `JSDOM`'s inner hooks, one of which resolve the relative paths.

## Notes
* I took into account protocol relative URIs (such as //google.com)
* I took into account that an url might end with a /

## Fixed issues
This PR should fix issue #33.