### PR TITLE
Add cli examples

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,6 +45,18 @@ with_common_options(program.command('html [urls...]'))
 // 	program.outputHelp();
 // });
 
+program.on('--help', () => {
+	console.log(`
+Examples:
+  Transform single web page to PDF
+    $ percollate pdf --output some.pdf https://example.com
+  Transform several web pages to a single PDF
+    $ percollate pdf --output some.pdf https://example.com/page1 https://example.com/page2
+  Custom page size and font size
+    $ percollate pdf --output some.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
+`);
+});
+
 program.parse(process.argv);
 
 // Show help by default when no arguments provided


### PR DESCRIPTION
Added some basic examples in the help commands for quick reference.

```node
Usage: cli [options] [command]

Options:
  -V, --version             output the version number
  -h, --help                output usage information

Commands:
  pdf [options] [urls...]   Bundle web pages as a PDF file
  epub [options] [urls...]  Bundle web pages as an EPUB file
  html [options] [urls...]  Bundle web pages as a HTML file

Examples:
  Transform single web page to PDF
    $ percollate pdf --output some.pdf https://example.com
  Transform several web pages to a single PDF
    $ percollate pdf --output some.pdf https://example.com/page1 https://example.com/page2
  Custom page size and font size
    $ percollate pdf --output some.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
```

PS: Regarding the `console.log` formatting, my original code are one log per line. However, the pre-commit hook automatically format those long sentenses in separate lines.  :-(
