### PR TITLE
PDF outline [WIP]

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const css = require('css');
 const slugify = require('slugify');
 const Readability = require('./vendor/readability');
 const pkg = require('./package.json');
+const uuid = require('uuid/v1');
 
 const spinner = ora();
 
@@ -94,7 +95,14 @@ async function cleanup(url) {
 
 		spinner.succeed();
 
-		return { ...parsed, url };
+		const page_id = `percollate-page-${uuid()}`;
+		const page_marker = `<a href='#${page_id}' class='no-href' id='${page_id}'></a>`;
+
+		return {
+			...parsed,
+			page_marker: page_marker,
+			url
+		};
 	} catch (error) {
 		spinner.fail(error.message);
 		throw error;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"puppeteer": "^1.8.0",
 		"slugify": "^1.3.1",
 		"srcset": "^1.0.0",
-		"tmp": "^0.0.33"
+		"tmp": "^0.0.33",
+		"uuid": "^3.3.2"
 	},
 	"bin": {
 		"percollate": "./cli.js"

--- a/templates/default.html
+++ b/templates/default.html
@@ -13,6 +13,7 @@
 	<article class='article'>
 		<header class='article__header'>
 			<h1 class='article__title'>
+				{{ item.page_marker}}
 				{{ item.title }}
 			</h1>
 			{% if item.byline %}


### PR DESCRIPTION
This is an exploration of solutions for https://github.com/danburzo/percollate/issues/47. 

Seems that creating an empty anchor that references itself works to generate a named object in the PDF in the form of:

```
130 0 obj
<</percollate-page-6e3c13e0-d632-11e8-bf82-9feebddd5cb5 [28 0 R /XYZ 27.999998 566.95996 0]>>
endobj
```

Now, with an appropriate tool, we should be able to write a document outline (Table of contents) in the PDF to point to this.