### PR TITLE
Fix "ReferenceError: URL is not defined" for node < v10.0.0

### DIFF
--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -1,4 +1,5 @@
 const srcset = require('srcset');
+const URL = require('url').URL;
 
 function imagesAtFullSize(doc) {
 	/*


### PR DESCRIPTION
`ReferenceError: URL is not defined` error occurs at the following line since `URL` class is not available as global object until `v10.0.0`

https://github.com/danburzo/percollate/blob/2925f0c033a2df4f158c3ad2bb6b8f7c9448e0e6/src/enhancements.js#L76-L79

This PR fixes it by requiring `URL` module. 

**Edit:** Oh I actually realized I directly sent the PR.. :smile:  let me know if I should create an issue. 