### PR TITLE
Prefer the AMP version of an article

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `pdf`, `epub`, and `html` commands have these options:
 | `--template`   | Path to a custom HTML template                                                                                 |
 | `--style`      | Path to a custom CSS                                                                                           |
 | `--css`        | Additional CSS styles you can pass from the command-line to override the default/custom stylesheet styles      |
+| `--no-amp`     | Don't prefer the AMP version of the web page                                                                   |
 
 ## Examples
 
@@ -180,10 +181,11 @@ An example from the [default stylesheet](./templates/default.css):
 ## How it works
 
 1. Fetch the page(s) using [`got`](https://github.com/sindresorhus/got)
-2. [Enhance](./src/enhancements.js) the DOM using [`jsdom`](https://github.com/jsdom/jsdom)
-3. Pass the DOM through [`mozilla/readability`](https://github.com/mozilla/readability) to strip unnecessary elements
-4. Apply the [HTML template](./templates/default.html) and the [print stylesheet](./templates/default.css) to the resulting HTML
-5. Use [`puppeteer`](https://github.com/GoogleChrome/puppeteer) to generate a PDF from the page
+2. If an AMP version of the page exists, use that instead (disable with `--no-amp` flag)
+3. [Enhance](./src/enhancements.js) the DOM using [`jsdom`](https://github.com/jsdom/jsdom)
+4. Pass the DOM through [`mozilla/readability`](https://github.com/mozilla/readability) to strip unnecessary elements
+5. Apply the [HTML template](./templates/default.html) and the [print stylesheet](./templates/default.css) to the resulting HTML
+6. Use [`puppeteer`](https://github.com/GoogleChrome/puppeteer) to generate a PDF from the page
 
 ## Limitations
 

--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,7 @@ function with_common_options(cmd) {
 		.option('--style [stylesheet]', 'Path to custom CSS')
 		.option('--css [style]', 'Additional CSS style')
 		.option('--individual', 'Export each web page as an individual file')
-		.option('--no-amp', "Don't use the AMP version when available");
+		.option('--no-amp', "Don't prefer the AMP version of the web page");
 }
 
 program.version(pkg.version);
@@ -49,13 +49,19 @@ with_common_options(program.command('html [urls...]'))
 program.on('--help', () => {
 	console.log(`
 Examples:
-  Transform single web page to PDF
-    $ percollate pdf --output some.pdf https://example.com
-  Transform several web pages to a single PDF
-    $ percollate pdf --output some.pdf https://example.com/page1 https://example.com/page2
-  Custom page size and font size
-    $ percollate pdf --output some.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
-`);
+
+  Single web page to PDF:
+
+    percollate pdf --output my.pdf https://example.com
+  
+  Several web pages to a single PDF:
+
+    percollate pdf --output my.pdf https://example.com/1 https://example.com/2
+  
+  Custom page size and font size:
+    
+    percollate pdf --output my.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
+	`);
 });
 
 program.parse(process.argv);

--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,8 @@ function with_common_options(cmd) {
 		.option('--template [template]', 'Path to custom HTML template')
 		.option('--style [stylesheet]', 'Path to custom CSS')
 		.option('--css [style]', 'Additional CSS style')
-		.option('--individual', 'Export each web page as an individual file');
+		.option('--individual', 'Export each web page as an individual file')
+		.option('--no-amp', "Don't use the AMP version when available");
 }
 
 program.version(pkg.version);

--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -1,6 +1,22 @@
 const srcset = require('srcset');
 const URL = require('url').URL;
 
+/* 
+	Convert AMP markup to HMTL markup
+	(naive implementation)
+*/
+function ampToHtml(doc) {
+	Array.from(doc.querySelectorAll('amp-img')).forEach(ampImg => {
+		if (ampImg.parentNode) {
+			let img = doc.createElement('img');
+			for (let attr of ampImg.attributes) {
+				img.setAttribute(attr.name, attr.value);
+			}
+			ampImg.parentNode.replaceChild(img, ampImg);
+		}
+	});
+}
+
 function imagesAtFullSize(doc) {
 	/*
 		Replace:
@@ -122,6 +138,7 @@ function singleImgToFigure(doc) {
 }
 
 module.exports = {
+	ampToHtml,
 	imagesAtFullSize,
 	noUselessHref,
 	wikipediaSpecific,

--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -1,19 +1,15 @@
 const srcset = require('srcset');
 const URL = require('url').URL;
+const replaceElementType = require('./replace-element-type');
 
 /* 
 	Convert AMP markup to HMTL markup
-	(naive implementation)
+	(naive / incomplete implementation)
 */
 function ampToHtml(doc) {
+	// Convert <amp-img> to <img>
 	Array.from(doc.querySelectorAll('amp-img')).forEach(ampImg => {
-		if (ampImg.parentNode) {
-			let img = doc.createElement('img');
-			for (let attr of ampImg.attributes) {
-				img.setAttribute(attr.name, attr.value);
-			}
-			ampImg.parentNode.replaceChild(img, ampImg);
-		}
+		replaceElementType(ampImg, 'img', doc);
 	});
 }
 

--- a/src/replace-element-type.js
+++ b/src/replace-element-type.js
@@ -1,0 +1,13 @@
+/*
+	Replace the element type (tag name) of an element.
+	Does not copy over the children elements (yet).
+ */
+module.exports = function(el, type, doc) {
+	if (el.parentNode) {
+		let new_el = doc.createElement(type);
+		for (let attr of el.attributes) {
+			new_el.setAttribute(attr.name, attr.value);
+		}
+		el.parentNode.replaceChild(new_el, el);
+	}
+};


### PR DESCRIPTION
Fixes #69. 

If an AMP version of the article is available, we can assume (?) that the markup there will be more sensible than on the full-HTML page. Also added a `--no-amp` just in case the AMP version produces inferior results.

The `ampToHtml` enhancement tries to fix some amp tags (currently just `<amp-img>` to `<img>`) and can be extended later if we figure out what elements need to be transformed further.