### PR TITLE
add decompress option to got

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ async function cleanup(url, options) {
 		const content = (await got(encodeURI(decodeURI(url)), {
 			headers: {
 				'user-agent': `percollate/${pkg.version}`
-			}
+			},
+			decompress: options.decompress
 		})).body;
 		spinner.succeed();
 


### PR DESCRIPTION
when I want to create a pdf like this:
```
const urlList = ['https://mp.weixin.qq.com/s/3Cy7dZordk6NbxYCBFSOeg'];
percollate.configure();
percollate.pdf(urlList, {
  output: 'test.pdf'
});
```
will get a decompress error.like this:
```
const urlList = ['https://mp.weixin.qq.com/s/3Cy7dZordk6NbxYCBFSOeg'];
percollate.configure();
percollate.pdf(urlList, {
  output: 'test.pdf',
  decompress: false
});
```
everything is ok.