### PR TITLE
Add installation information about the packaged Arch's AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ npm install -g percollate
 yarn global add percollate
 ```
 
+There's also a packaged version on [Arch's
+AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository)
+repositories, and you can install using your local [AUR
+helper](https://wiki.archlinux.org/index.php/AUR_helpers) (yay, pacaur,
+etc).
+
+```bash
+# using yay
+yay -S nodejs-percollate
+```
+
 Percollate and its dependencies require Node.js version 10.22.0 or later.
 
 ## Usage


### PR DESCRIPTION
I've packaged the app to the [Arch's AUR repositories](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=nodejs-percollate) so it's available on the distro repositories.