### PR TITLE
Optimize number of HTML parse/serialize pairs in cleanup phase.

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,10 +211,6 @@ async function cleanup(url, options) {
 			remoteResources = mapRemoteResources(dom.window.document);
 		}
 
-		const serializer = options.xhtml
-			? el => new dom.window.XMLSerializer().serializeToString(el)
-			: el => el.innerHTML;
-
 		// Run through readability and return
 		const R = new Readability(dom.window.document, {
 			classesToPreserve: [
@@ -226,7 +222,16 @@ async function cleanup(url, options) {
 				 */
 				'anchor'
 			],
-			serializer
+			/*
+				Change Readability's serialization to return 
+				a DOM element (instead of a HTML string) 
+				as the `.content` property returned from `.parse()`
+
+				This makes it easier for us to run subsequent
+				transformations (sanitization, hyphenation, etc.)
+				without having to parse/serialize the HTML repeatedly.
+			 */
+			serializer: el => el
 		});
 
 		// TODO: find better solution to prevent Readability from
@@ -238,6 +243,16 @@ async function cleanup(url, options) {
 		const parsed = R.parse() || {};
 
 		out.write(' ✓\n');
+
+		/*
+			Select the appropriate serialization method
+			based on the bundle target. EPUBs need the 
+			content to be XHTML (produced by a XML serializer),
+			rather than normal HTML.
+		 */
+		const serializer = options.xhtml
+			? el => new dom.window.XMLSerializer().serializeToString(el)
+			: el => el.innerHTML;
 
 		return {
 			id: `percollate-page-${uuid()}`,


### PR DESCRIPTION
The sanitizer (DOMPurify) accepts as an argument a DOM element, in addition to a string. Therefore, make `Readability.parse()` return a DOM element instead of a HTML string, to avoid an extra serialization/parse step. 

This should also make it clearer/easier where to introduce the hyphenation step as part of #114.
