### PR TITLE
Fix epubgen resolving before epub is fully generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,7 +418,7 @@ async function bundleEpub(items, options) {
 	const author =
 		options.author || (items.length === 1 ? items[0].byline : undefined);
 
-	epubgen(
+	await epubgen(
 		{
 			filetype: 'epub',
 			title,
@@ -543,147 +543,158 @@ async function html(urls, options) {
  */
 
 async function epubgen(data, output_path, options) {
-	const template_base = path.join(__dirname, 'templates/epub/');
+	const wrapAsync = inner => {
+		return new Promise((resolve, reject) => {
+			inner(resolve, reject).catch(reject);
+		});
+	};
 
-	const output = _fs.createWriteStream(output_path);
-	const archive = archiver('zip', {
-		store: true
-	});
+	return wrapAsync(async resolve => {
+		const template_base = path.join(__dirname, 'templates/epub/');
 
-	output
-		.on('close', () => {
-			out.write(archive.pointer() + ' total bytes');
-			out.write(
-				'archiver has been finalized and the output file descriptor has closed.'
-			);
-		})
-		.on('end', () => {
-			out.write('Data has been drained');
+		const output = _fs.createWriteStream(output_path);
+		const archive = archiver('zip', {
+			store: true
 		});
 
-	archive
-		.on('warning', err => {
-			throw err;
-		})
-		.on('error', err => {
-			throw err;
-		})
-		.pipe(output);
+		output
+			.on('close', () => {
+				out.write(archive.pointer() + ' total bytes');
+				out.write(
+					'archiver has been finalized and the output file descriptor has closed.'
+				);
+			})
+			.on('end', () => {
+				out.write('Data has been drained');
+			})
+			.on('finish', resolve);
 
-	// mimetype file must be first
-	archive.append('application/epub+zip', { name: 'mimetype' });
+		archive
+			.on('warning', err => {
+				throw err;
+			})
+			.on('error', err => {
+				throw err;
+			})
+			.pipe(output);
 
-	// static files from META-INF
-	archive.directory(path.join(template_base, 'META-INF'), 'META-INF');
+		// mimetype file must be first
+		archive.append('application/epub+zip', { name: 'mimetype' });
 
-	const contentTemplate = await fs.readFile(
-		path.join(template_base, 'OEBPS/content.xhtml'),
-		'utf8'
-	);
-	const navTemplate = await fs.readFile(
-		path.join(template_base, 'OEBPS/nav.xhtml'),
-		'utf8'
-	);
-	const tocTemplate = await fs.readFile(
-		path.join(template_base, 'OEBPS/toc.ncx'),
-		'utf8'
-	);
-	const opfTemplate = await fs.readFile(
-		path.join(template_base, 'OEBPS/content.opf'),
-		'utf8'
-	);
+		// static files from META-INF
+		archive.directory(path.join(template_base, 'META-INF'), 'META-INF');
 
-	archive.append(data.style || '', { name: 'OEBPS/style.css' });
-
-	let remoteResources = [];
-	data.items.forEach(item => {
-		remoteResources = remoteResources.concat(item.remoteResources || []);
-		let item_content = nunjucks.renderString(contentTemplate, {
-			...data,
-			item
-		});
-		archive.append(item_content, { name: `OEBPS/${item.id}.xhtml` });
-	});
-
-	for (let i = 0; i < remoteResources.length; i++) {
-		let entry = remoteResources[i];
-		try {
-			if (options.debug) {
-				out.write(`Fetching: ${entry[0]}\n`);
-			}
-			let stream = (
-				await fetch(entry[0], {
-					headers: {
-						'user-agent': UA
-					},
-					timeout: 10 * 1000
-				})
-			).body;
-			archive.append(stream, { name: `OEBPS/${entry[1]}` });
-		} catch (err) {
-			console.log(err);
-		}
-	}
-
-	const assets = [
-		{
-			id: 'style',
-			href: 'style.css',
-			mimetype: 'text/css'
-		}
-	];
-
-	if (data.cover) {
-		const COVER_TEMPLATE = path.join(__dirname, 'templates/cover.html');
-		const cover_html = nunjucks.renderString(
-			await fs.readFile(COVER_TEMPLATE, 'utf8'),
-			data
+		const contentTemplate = await fs.readFile(
+			path.join(template_base, 'OEBPS/content.xhtml'),
+			'utf8'
+		);
+		const navTemplate = await fs.readFile(
+			path.join(template_base, 'OEBPS/nav.xhtml'),
+			'utf8'
+		);
+		const tocTemplate = await fs.readFile(
+			path.join(template_base, 'OEBPS/toc.ncx'),
+			'utf8'
+		);
+		const opfTemplate = await fs.readFile(
+			path.join(template_base, 'OEBPS/content.opf'),
+			'utf8'
 		);
 
-		const browser = await launch(options, {
-			width: 400,
-			height: 565
+		archive.append(data.style || '', { name: 'OEBPS/style.css' });
+
+		let remoteResources = [];
+		data.items.forEach(item => {
+			remoteResources = remoteResources.concat(
+				item.remoteResources || []
+			);
+			let item_content = nunjucks.renderString(contentTemplate, {
+				...data,
+				item
+			});
+			archive.append(item_content, { name: `OEBPS/${item.id}.xhtml` });
 		});
-		const page = await browser.newPage();
 
-		await page.setUserAgent(UA);
-		await page.setContent(cover_html, { waitUntil: 'load' });
+		for (let i = 0; i < remoteResources.length; i++) {
+			let entry = remoteResources[i];
+			try {
+				if (options.debug) {
+					out.write(`Fetching: ${entry[0]}\n`);
+				}
+				let stream = (
+					await fetch(entry[0], {
+						headers: {
+							'user-agent': UA
+						},
+						timeout: 10 * 1000
+					})
+				).body;
+				archive.append(stream, { name: `OEBPS/${entry[1]}` });
+			} catch (err) {
+				console.log(err);
+			}
+		}
 
-		let buff = await page.screenshot({
-			type: 'png',
-			fullPage: true
+		const assets = [
+			{
+				id: 'style',
+				href: 'style.css',
+				mimetype: 'text/css'
+			}
+		];
+
+		if (data.cover) {
+			const COVER_TEMPLATE = path.join(__dirname, 'templates/cover.html');
+			const cover_html = nunjucks.renderString(
+				await fs.readFile(COVER_TEMPLATE, 'utf8'),
+				data
+			);
+
+			const browser = await launch(options, {
+				width: 400,
+				height: 565
+			});
+			const page = await browser.newPage();
+
+			await page.setUserAgent(UA);
+			await page.setContent(cover_html, { waitUntil: 'load' });
+
+			let buff = await page.screenshot({
+				type: 'png',
+				fullPage: true
+			});
+
+			archive.append(buff, { name: 'OEBPS/cover.png' });
+
+			await browser.close();
+		}
+
+		const nav = nunjucks.renderString(navTemplate, data);
+		const opf = nunjucks.renderString(opfTemplate, {
+			...data,
+			assets,
+			cover: data.cover
+				? {
+						id: 'cover',
+						href: 'cover.png',
+						mimetype: 'image/png'
+				  }
+				: undefined,
+			remoteResources: remoteResources.map(entry => ({
+				id: entry[1].replace(/[^a-z0-9]/gi, ''),
+				href: entry[1],
+				mimetype: mimetype.lookup(entry[1])
+			}))
 		});
 
-		archive.append(buff, { name: 'OEBPS/cover.png' });
+		const toc = nunjucks.renderString(tocTemplate, data);
 
-		await browser.close();
-	}
+		archive.append(nav, { name: 'OEBPS/nav.xhtml' });
+		archive.append(opf, { name: 'OEBPS/content.opf' });
+		archive.append(toc, { name: 'OEBPS/toc.ncx' });
 
-	const nav = nunjucks.renderString(navTemplate, data);
-	const opf = nunjucks.renderString(opfTemplate, {
-		...data,
-		assets,
-		cover: data.cover
-			? {
-					id: 'cover',
-					href: 'cover.png',
-					mimetype: 'image/png'
-			  }
-			: undefined,
-		remoteResources: remoteResources.map(entry => ({
-			id: entry[1].replace(/[^a-z0-9]/gi, ''),
-			href: entry[1],
-			mimetype: mimetype.lookup(entry[1])
-		}))
+		archive.finalize();
 	});
-
-	const toc = nunjucks.renderString(tocTemplate, data);
-
-	archive.append(nav, { name: 'OEBPS/nav.xhtml' });
-	archive.append(opf, { name: 'OEBPS/content.opf' });
-	archive.append(toc, { name: 'OEBPS/toc.ncx' });
-
-	archive.finalize();
 }
 
 module.exports = {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -27,7 +27,7 @@ tape('files exists', async t => {
 	t.pass();
 });
 
-tape('epub', async t => {
+tape('generates valid epub', async t => {
 	percollate.configure();
 	await percollate.epub([testUrl], {
 		output: testEpub

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,7 @@
 let tape = require('tape');
 const fs = require('fs');
 const percollate = require('..');
+const epubchecker = require('epubchecker');
 
 const testUrl = 'https://de.wikipedia.org/wiki/JavaScript';
 const testPdf = `${__dirname}/percollate-output.pdf`;
@@ -16,9 +17,6 @@ async function generateTestFiles() {
 	await percollate.html([testUrl], {
 		output: testHtml
 	});
-	await percollate.epub([testUrl], {
-		output: testEpub
-	});
 }
 
 tape('files exists', async t => {
@@ -26,8 +24,19 @@ tape('files exists', async t => {
 	await generateTestFiles();
 	t.true(fs.existsSync(testPdf));
 	t.true(fs.existsSync(testHtml));
-	t.true(fs.existsSync(testEpub));
 	t.pass();
+});
+
+tape('epub', async t => {
+	percollate.configure();
+	await percollate.epub([testUrl], {
+		output: testEpub
+	});
+
+	t.true(fs.existsSync(testEpub));
+
+	const report = await epubchecker(testEpub);
+	t.equal(report.checker.nFatal, 0);
 });
 
 tape('website to html & html to pdf', async t => {


### PR DESCRIPTION
I'm using percollate as a library and noticed that when `percollate.epub` resolves the EPUB is actually not fully generated yet.

This PR fixes that in the simplest, but not ideal, way. I made `epubgen` return a Promise, that:

* Resolves when `archiver` emits the 'finish' event
* Rejects when anything in `epubgen` throws

This solution is not ideal, because we now have this situation:

```js
async function epubgen(data, output_path, options) {
  return new Promise(async (resolve, reject) => {
    // original code here
  });
}
```

I.e. an async function used as Promise resolver. This is tricky because errors that happen in this Promise resolver will not be correctly relayed to the outer promise. To work around this I wrapped the original code in this, eh, beauty:

```js
const wrapAsync = inner => {
  return new Promise((resolve, reject) => {
    inner(resolve, reject).catch(reject);
  });
};
```

Which ensures that the outer promise is rejected whenever an error is thrown inside the Promise resolver. This required the least amount of code (even though the diff is quite large, due to having to wrap the original code), which was convenient for me since I'm not very familiar with this code.

Ideally `epubgen` would be restructured such that you don't have to pass an async function to the Promise constructor, but that would require some more changes that I didn't feel comfortable with.

@danburzo please let me know if this is acceptable for you.