### PR TITLE
Enhancement: Wrap <pre> elements in <figure>s; fixes #66

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ const {
 	relativeToAbsoluteURIs,
 	singleImgToFigure,
 	expandDetailsElements,
-	githubSpecific
+	githubSpecific,
+	wrapPreBlocks
 } = require('./src/enhancements');
 const mapRemoteResources = require('./src/remote-resources');
 const get_style_attribute_value = require('./src/get-style-attribute-value');
@@ -49,7 +50,8 @@ const enhancePage = function (dom) {
 		noUselessHref,
 		expandDetailsElements,
 		wikipediaSpecific,
-		githubSpecific
+		githubSpecific,
+		wrapPreBlocks
 	].forEach(enhancement => {
 		enhancement(dom.window.document);
 	});

--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -220,7 +220,8 @@ function expandDetailsElements(doc) {
 }
 
 /*
-	Wrap <pre> blocks in <figure> elements
+	Wrap <pre> blocks in <figure> elements,
+	to make sure Readability preserves them.
  */
 function wrapPreBlocks(doc) {
 	Array.from(doc.querySelectorAll('pre')).forEach(pre => {

--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -219,6 +219,24 @@ function expandDetailsElements(doc) {
 	);
 }
 
+/*
+	Wrap <pre> blocks in <figure> elements
+ */
+function wrapPreBlocks(doc) {
+	Array.from(doc.querySelectorAll('pre')).forEach(pre => {
+		if (pre.parentNode && !pre.parentNode.matches('figure')) {
+			let fig = doc.createElement('figure');
+			fig.appendChild(pre.cloneNode(true));
+			/*
+				If the <pre> is the only child (of a <div> or <p>),
+				also remove this parent in the process.
+			 */
+			let to_replace = pre.matches(':only-child') ? pre.parentNode : pre;
+			to_replace.parentNode.replaceChild(fig, to_replace);
+		}
+	});
+}
+
 module.exports = {
 	ampToHtml,
 	fixLazyLoadedImages,
@@ -228,5 +246,6 @@ module.exports = {
 	relativeToAbsoluteURIs,
 	singleImgToFigure,
 	expandDetailsElements,
-	githubSpecific
+	githubSpecific,
+	wrapPreBlocks
 };

--- a/test/enhancements.test.js
+++ b/test/enhancements.test.js
@@ -157,7 +157,8 @@ tape('wrapPreBlocks', t => {
 	t.equal(
 		doc1.body.innerHTML,
 		`<p>Here is the command:</p>
-		<figure><pre>cd my-app/</pre></figure>`
+		<figure><pre>cd my-app/</pre></figure>`,
+		'Wraps <pre> when appropriate'
 	);
 
 	const doc2 = dom`
@@ -169,7 +170,8 @@ tape('wrapPreBlocks', t => {
 	t.equal(
 		doc2.body.innerHTML,
 		`<p>Here is the command:</p>
-		<figure><pre>cd my-app/</pre><figcaption>The command</figcaption></figure>`
+		<figure><pre>cd my-app/</pre><figcaption>The command</figcaption></figure>`,
+		"Doesn't double-wrap in <figure>"
 	);
 
 	const doc3 = dom`
@@ -181,7 +183,8 @@ tape('wrapPreBlocks', t => {
 	t.equal(
 		doc3.body.innerHTML,
 		`<p>Here is the command:</p>
-		<figure><pre>cd my-app/</pre></figure>`
+		<figure><pre>cd my-app/</pre></figure>`,
+		'Removes useless wrapping element'
 	);
 
 	t.end();

--- a/test/enhancements.test.js
+++ b/test/enhancements.test.js
@@ -3,7 +3,8 @@ const { JSDOM } = require('jsdom');
 const {
 	wikipediaSpecific,
 	githubSpecific,
-	imagesAtFullSize
+	imagesAtFullSize,
+	wrapPreBlocks
 } = require('../src/enhancements');
 
 const dom = content => new JSDOM(content).window.document;
@@ -141,6 +142,46 @@ tape('githubSpecific', t => {
 		doc.querySelector('h2 a').getAttribute('id'),
 		'some-anchor',
 		'fix GitHub anchors'
+	);
+
+	t.end();
+});
+
+tape('wrapPreBlocks', t => {
+	const doc1 = dom`
+		<p>Here is the command:</p>
+		<pre>cd my-app/</pre>`;
+
+	wrapPreBlocks(doc1);
+
+	t.equal(
+		doc1.body.innerHTML,
+		`<p>Here is the command:</p>
+		<figure><pre>cd my-app/</pre></figure>`
+	);
+
+	const doc2 = dom`
+		<p>Here is the command:</p>
+		<figure><pre>cd my-app/</pre><figcaption>The command</figcaption></figure>`;
+
+	wrapPreBlocks(doc2);
+
+	t.equal(
+		doc2.body.innerHTML,
+		`<p>Here is the command:</p>
+		<figure><pre>cd my-app/</pre><figcaption>The command</figcaption></figure>`
+	);
+
+	const doc3 = dom`
+		<p>Here is the command:</p>
+		<div><pre>cd my-app/</pre></div>`;
+
+	wrapPreBlocks(doc3);
+
+	t.equal(
+		doc3.body.innerHTML,
+		`<p>Here is the command:</p>
+		<figure><pre>cd my-app/</pre></figure>`
 	);
 
 	t.end();


### PR DESCRIPTION
Code blocks are frequently marked up as `<pre>` blocks. When these blocks are very short, Readability will strip them
away unless they're wrapped in a `<figure>` element. (Which they should, in the first place!)

This PR introduces the `wrapPreBlocks` enhancement that wraps these elements appropriately. 

Fixes #66.