### PR TITLE
Add --wait option to process URLs sequentially.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Use the `--url` option to supply the source's original URL.
 curl https://example.com | percollate pdf - --url=https://example.com
 ```
 
+#### `-w, --wait`
+
+By default, percollate processes URLs in parallel. Use the `--wait` option to process them sequentially instead, with a pause between items. The delay is specified in seconds, and can be zero.
+
+```bash
+percollate epub --wait=1 url1 url2 url3
+```
+
 #### `--individual`
 
 By default, percollate bundles all web pages in a single file. Use the `--individual` flag to export each source to a separate file.

--- a/cli.js
+++ b/cli.js
@@ -79,6 +79,9 @@ Commmon options:
   
   -u, --url=<url>    Sets the base URL when HTML is provided on stdin.
                      Multiple URL options can be specified.
+
+  -w, --wait=<sec>   Process the provided URLs sequentially, 
+                     pausing a number of seconds between items.
   
   -t <title>,        The bundle title.
   --title=<title>

--- a/src/cli-opts.js
+++ b/src/cli-opts.js
@@ -71,6 +71,7 @@ let opts_with_optarg = new Set([
 	'style',
 	'css',
 	'url',
+	'wait',
 	'title',
 	'author'
 ]);
@@ -78,6 +79,7 @@ let opts_with_arr = new Set(['url']);
 let aliases = {
 	o: 'output',
 	u: 'url',
+	w: 'wait',
 	t: 'title',
 	a: 'author',
 	h: 'help',

--- a/src/util/promises.js
+++ b/src/util/promises.js
@@ -1,0 +1,27 @@
+export function timeout(ms = 0) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function resolveSequence(delay = 0) {
+	return function (arr, fn) {
+		return arr.reduce((chain, item, i) => {
+			return chain
+				.then(async result => {
+					if (delay && i > 0) {
+						await timeout(delay * 1000);
+					}
+					return result;
+				})
+				.then(result => {
+					return fn(item, i, arr).then(content => [
+						...result,
+						content
+					]);
+				});
+		}, Promise.resolve([]));
+	};
+}
+
+export function resolveParallel(arr, fn) {
+	return Promise.all(arr.map(fn));
+}

--- a/src/util/promises.js
+++ b/src/util/promises.js
@@ -1,27 +1,32 @@
-export function timeout(ms = 0) {
-	return new Promise(resolve => setTimeout(resolve, ms));
+/*
+	Promise aggregation functions
+	-----------------------------
+ */
+
+/*
+	Run the asynchronous `fn` function sequentially
+	on each item in the `items` array, with an optional
+	`delay` in milliseconds between items.
+ */
+export function resolveSequence(arr, fn, delay = 0) {
+	return arr.reduce((chain, item, i) => {
+		return chain
+			.then(async result => {
+				if (delay && i > 0) {
+					await new Promise(r => setTimeout(r, delay));
+				}
+				return result;
+			})
+			.then(result => {
+				return fn(item, i, arr).then(content => [...result, content]);
+			});
+	}, Promise.resolve([]));
 }
 
-export function resolveSequence(delay = 0) {
-	return function (arr, fn) {
-		return arr.reduce((chain, item, i) => {
-			return chain
-				.then(async result => {
-					if (delay && i > 0) {
-						await timeout(delay * 1000);
-					}
-					return result;
-				})
-				.then(result => {
-					return fn(item, i, arr).then(content => [
-						...result,
-						content
-					]);
-				});
-		}, Promise.resolve([]));
-	};
-}
-
-export function resolveParallel(arr, fn) {
-	return Promise.all(arr.map(fn));
+/*
+	Run the asynchronous `fn` function in parallel
+	on each item in the `items` array.
+ */
+export function resolveParallel(items, fn) {
+	return Promise.all(items.map(fn));
 }

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -1,5 +1,6 @@
 import { resolveSequence, resolveParallel } from '../src/util/promises.js';
 import tape from 'tape';
+import { performance } from 'perf_hooks';
 
 let arr = [1, 2, 3];
 let epsilon = 100; // milliseconds +/- error

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -1,0 +1,30 @@
+import { resolveSequence, resolveParallel } from '../src/util/promises.js';
+import tape from 'tape';
+
+let arr = [1, 2, 3];
+let epsilon = 100; // milliseconds +/- error
+
+tape('resolveSequence', async t => {
+	let begin = performance.now();
+	let delay = 500;
+	let res = await resolveSequence(arr, i => Promise.resolve(i), delay);
+	let expected_duration = delay * (arr.length - 1);
+	t.deepEqual(res, arr, 'correct result is returned');
+	t.ok(
+		Math.abs(performance.now() - begin - expected_duration) < epsilon,
+		'delay is applied'
+	);
+	t.end();
+});
+
+tape('resolveParallel', async t => {
+	let begin = performance.now();
+	let res = await resolveParallel(arr, i => Promise.resolve(i));
+	let expected_duration = 0;
+	t.deepEqual(res, arr, 'correct result is returned');
+	t.ok(
+		Math.abs(performance.now() - begin - expected_duration) < epsilon,
+		"there's no delay"
+	);
+	t.end();
+});


### PR DESCRIPTION
Adds the `-w, --wait=<sec>` global CLI option to pause between processing URLs for a number of seconds. If unspecified, URLs are processed in parallel as before.

Fixes #133.