### PR TITLE
use fileURLToPath for windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ import {
 import mapRemoteResources from './src/remote-resources.js';
 import inlineImages from './src/inline-images.js';
 import get_style_attribute_value from './src/get-style-attribute-value.js';
+import { fileURLToPath } from 'url';
 
 const out = process.stdout;
 
@@ -644,8 +645,9 @@ async function epubgen(data, output_path, options) {
 	};
 
 	return wrapAsync(async (resolve, reject) => {
-		const template_base = new URL('templates/epub/', import.meta.url)
-			.pathname;
+		const template_base = fileURLToPath(
+			new URL('templates/epub/', import.meta.url)
+		);
 
 		const output = fs.createWriteStream(output_path);
 		const archive = archiver('zip', {


### PR DESCRIPTION
This change makes it possible to generate epubs on windows by using a cross plattform compatible way to resolve the path.

See: https://github.com/nodejs/node/issues/37845

The same problem exists for the tests https://github.com/danburzo/percollate/blob/9ff43d022e37e2faf0297e02a213e26b98a78326/test/index.test.js#L30 and https://github.com/danburzo/percollate/blob/9ff43d022e37e2faf0297e02a213e26b98a78326/test/index.test.js#L35 but I couldn't get it to work.
My attempt was by using `fileURLToPath()` in the same way as in this PR and replacing this line https://github.com/danburzo/percollate/blob/9ff43d022e37e2faf0297e02a213e26b98a78326/index.js#L154 with `decodeURI(fileURLToPath(url))`, but `readFile()` does not work with windows style paths, like `C:\Users\something`
So I left that out of here.