### PR TITLE
Fix cli help --author flag typo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -87,7 +87,7 @@ Commmon options:
   --title=<title>
 
   -a <author>,       The bundle author.
-  --author=<title>
+  --author=<author>
   
   --individual       Export each web page as an individual file.
   


### PR DESCRIPTION
Thanks for the great tool. I noticed (what I believe is) a typo in the CLI help text for the `--author` flag and thought I'd PR a fix.