### PR TITLE
Better handling of stdin, stdout, stderr

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ const pkg = JSON.parse(
 );
 
 if (opts.debug) {
-	console.log({
+	console.error({
 		command,
 		operands,
 		opts
@@ -27,22 +27,30 @@ if (opts.help) {
 	outputHelp();
 }
 
-if (!command || !operands.length) {
-	outputHelp();
+if (!operands.length) {
+	operands.push('-');
 }
 
 switch (command) {
 	case 'pdf':
+		if (opts.output === '-') {
+			console.error(`Output to <stdout> is only supported for HTML.`);
+			process.exit(1);
+		}
 		pdf(operands, opts);
 		break;
 	case 'epub':
+		if (opts.output === '-') {
+			console.error(`Output to <stdout> is only supported for HTML.`);
+			process.exit(1);
+		}
 		epub(operands, opts);
 		break;
 	case 'html':
 		html(operands, opts);
 		break;
 	default:
-		outputHelp();
+		outputHelp(true);
 }
 
 /*
@@ -50,99 +58,102 @@ switch (command) {
 	--------------
  */
 
-function outputHelp() {
-	console.log(
-		`percollate v${pkg.version}
+function outputHelp(error) {
+	const helpText = `percollate v${pkg.version}
 
 Usage: percollate <command> [options] url [url]...
 
 Commands:
 
-  pdf                Bundle web pages as a PDF file
-  epub               Bundle web pages as an EPUB file.
-  html               Bundle web pages as a HTML file.
+	pdf                  Bundle web pages as a PDF file.
+	epub                 Bundle web pages as an EPUB file.
+	html                 Bundle web pages as a HTML file.
 
 Commmon options:
 
-  -h, --help           Output usage information.
-  -V, --version        Output program version.
-  --debug              Print more detailed information.
+	-h, --help           Output usage information.
+	-V, --version        Output program version.
+	--debug              Print more detailed information.
 
-  -o <output>,         Path for the generated bundle.
-  --output=<path>  
+	-o <output>,         Path for the generated bundle.
+	--output=<path>      Use '-' to output to standard output ('stdout').
 
-  --template=<path>    Path to a custom HTML template.
-  
-  --style=<path>       Path to a custom CSS file.
-  
-  --css=<style>        Additional inline CSS style.
-  
-  -u, --url=<url>      Sets the base URL when HTML is provided on stdin.
-                       Multiple URL options can be specified.
+	--template=<path>    Path to a custom HTML template.
+	
+	--style=<path>       Path to a custom CSS file.
+	
+	--css=<style>        Additional inline CSS style.
+	
+	-u, --url=<url>      Sets the base URL when HTML is provided on stdin.
+											 Multiple URL options can be specified.
 
-  -w, --wait=<sec>     Process the provided URLs sequentially, 
-                       pausing a number of seconds between items.
-  
-  -t <title>,          The bundle title.
-  --title=<title>
+	-w, --wait=<sec>     Process the provided URLs sequentially, 
+											 pausing a number of seconds between items.
+	
+	-t <title>,          The bundle title.
+	--title=<title>
 
-  -a <author>,         The bundle author.
-  --author=<author>
-  
-  --individual         Export each web page as an individual file.
-  
-  --toc                Generate a Table of Contents.
-                       Implicitly enabled when bundling more than one item.
-  
-  --cover              Generate a cover for the PDF / EPUB.
-                       Implicitly enabled when bundling more than one item
-                       or the --title option is provided.
+	-a <author>,         The bundle author.
+	--author=<author>
+	
+	--individual         Export each web page as an individual file.
+	
+	--toc                Generate a Table of Contents.
+											 Implicitly enabled when bundling more than one item.
+	
+	--cover              Generate a cover for the PDF / EPUB.
+											 Implicitly enabled when bundling more than one item
+											 or the --title option is provided.
 
-  --browser=<browser>  One of 'chrome' (default), 'firefox'.
-                       Used for producing PDF and the cover image for EPUB.
-  
-  --hyphenate          Enable hyphenation. Enabled by default for PDF.
+	--browser=<browser>  One of 'chrome' (default), 'firefox'.
+											 Used for producing PDF and the cover image for EPUB.
+	
+	--hyphenate          Enable hyphenation. Enabled by default for PDF.
 
-  --inline             Embed images inline with the content.
-                       Fetches and converts images to Base64 'data:' URLs.
+	--inline             Embed images inline with the content.
+											 Fetches and converts images to Base64 'data:' URLs.
 
 Options to disable features:
 
-  --no-amp             Don't prefer the AMP version of the web page.
-  --no-toc             Don't generate a table of contents.
-  --no-cover           Don't generate a cover.
-  --no-hyphenate       Disable hyphenation.
+	--no-amp             Don't prefer the AMP version of the web page.
+	--no-toc             Don't generate a table of contents.
+	--no-cover           Don't generate a cover.
+	--no-hyphenate       Disable hyphenation.
 
 PDF options: 
 
-  --no-sandbox         Passed to Puppeteer.
+	--no-sandbox         Passed to Puppeteer.
 
 
 Operands:
 
-  percollate accepts one or more URLs.
-  
-  Use the hyphen character ('-') to specify 
-  that the HTML should be read from stdin.
+	percollate accepts one or more URLs.
+	
+	Use the hyphen character ('-') to specify 
+	that the HTML should be read from stdin.
 
 Examples:
 
-  Single web page to PDF:
+	Single web page to PDF:
 
-    percollate pdf --output my.pdf https://example.com
+		percollate pdf --output my.pdf https://example.com
 
-  Single web page read from stdin to PDF:
+	Single web page read from stdin to PDF:
 
-    curl https://example.com | percollate pdf -o my.pdf -u https://example.com -
-  
-  Several web pages to a single PDF:
+		curl https://example.com | percollate pdf -o my.pdf -u https://example.com -
+	
+	Several web pages to a single PDF:
 
-    percollate pdf --output my.pdf https://example.com/1 https://example.com/2
-  
-  Custom page size and font size:
-    
-    percollate pdf --output my.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
-`
-	);
+		percollate pdf --output my.pdf https://example.com/1 https://example.com/2
+	
+	Custom page size and font size:
+		
+		percollate pdf --output my.pdf --css "@page { size: A3 landscape } html { font-size: 18pt }" https://example.com
+`;
+	if (error) {
+		console.error(helpText);
+		process.exit(1);
+	}
+	console.log(helpText);
 	process.exit(0);
 }

--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ async function bundlePdf(items, options) {
 	await writeFile(output_path, pdf);
 
 	err.write(`Saved PDF: `);
-	out.write(output_path);
+	out.write(String(output_path));
 }
 
 /*
@@ -542,7 +542,7 @@ async function bundleEpub(items, options) {
 	);
 
 	err.write(`Saved EPUB: `);
-	out.write(output_path);
+	out.write(String(output_path));
 }
 
 /*
@@ -591,7 +591,7 @@ async function bundleHtml(items, options) {
 	const output_path = outputPath(items, options, '.html', options.slugCache);
 	await writeFile(output_path, html);
 	err.write(`Saved HTML: `);
-	out.write(output_path);
+	out.write(String(output_path));
 }
 
 async function generate(fn, urls, options = {}) {


### PR DESCRIPTION
Fixes #150.

* consume input from 'stdin' when no operands are provided
* output all info/errors to 'stderr'
* allow output HTML to 'stdout' with '-o -' option