### PR TITLE
Fixed issue with converting ArrayBuffer to base64

### DIFF
--- a/src/util/fetch-base64.js
+++ b/src/util/fetch-base64.js
@@ -3,5 +3,5 @@ import fetch from 'node-fetch';
 export default function fetchBase64(url, fetchOptions = {}) {
 	return fetch(url, fetchOptions)
 		.then(r => r.arrayBuffer())
-		.then(buff => buff.toString('base64'));
+		.then(buff => Buffer.from(buff).toString('base64'));
 }

--- a/src/util/fetch-base64.js
+++ b/src/util/fetch-base64.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import { Buffer } from 'node:buffer';
 
 export default function fetchBase64(url, fetchOptions = {}) {
 	return fetch(url, fetchOptions)


### PR DESCRIPTION
There seems to be an issue with generating Epub with inline images using the following command:
`percollate epub --inline https://da.m.wikipedia.org/wiki/Danmarks_historie`

The function `fetchBase64` does not properly convert the ArrayBuffer to base64 string and instead produces `[object ArrayBuffer]`.
Example of the output:
`<img data-file-height="355" data-file-width="330" decoding="async" src="data:image/png;base64,[object ArrayBuffer]" /> `

I have included a small patch that should fix this issue.