### PR TITLE
Fix regex to exclude Wikipedia links to image file pages

### DIFF
--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -56,7 +56,7 @@ function imagesAtFullSize(doc) {
 		/*
 			Exclude Wikipedia links to image file pages
 		*/
-		/wiki\/[a-zA-Z]+?:/,
+		/wikipedia\.org\/wiki\/[a-z]+:/i,
 
 		/* 
 			Exclude images embedded in Markdown files

--- a/src/enhancements.js
+++ b/src/enhancements.js
@@ -56,7 +56,7 @@ function imagesAtFullSize(doc) {
 		/*
 			Exclude Wikipedia links to image file pages
 		*/
-		/wiki\/File:/,
+		/wiki\/[a-zA-Z]+?:/,
 
 		/* 
 			Exclude images embedded in Markdown files


### PR DESCRIPTION
The regex to exclude the Wikipedia links does not always work as if you visit a page in a different language, i.e. Danish, the link will look differently:
`https://da.m.wikipedia.org/wiki/Fil:Danmark-locator.png`

This will break the images when using the --inline cli option as it will instead try to base64 encode contents of `https://da.m.wikipedia.org/wiki/Fil:Danmark-locator.png`, which is an HTML page.

I propose that we change the regex as shown in the commit to take into account different languages.